### PR TITLE
Revert "update url"

### DIFF
--- a/tests/Util/UriTest.php
+++ b/tests/Util/UriTest.php
@@ -37,7 +37,7 @@ class UriTest extends TestCase
     {
         $this->assertSame(
             'https://google.com/account/',
-            Uri::mergeUrls('https://google.com/', 'https://google.com/account/')
+            Uri::mergeUrls('http://google.com/', 'https://google.com/account/')
         );
         $this->assertSame('https://facebook.com/', Uri::mergeUrls('https://google.com/test/', '//facebook.com/'));
         $this->assertSame(


### PR DESCRIPTION
Reverts Codeception/lib-web#3

@Arhell The test called `testMergingScheme()` intentionally uses URLs with different schemes.