### PR TITLE
Fixing Markdown Code Syntax

### DIFF
--- a/src/Lib/Interfaces/Web.php
+++ b/src/Lib/Interfaces/Web.php
@@ -9,7 +9,7 @@ interface Web
     /**
      * Opens the page for the given relative URI.
      *
-     * ``` php
+     * ```php
      * <?php
      * // opens front page
      * $I->amOnPage('/');
@@ -25,7 +25,7 @@ interface Web
      * You can specify a specific HTML element (via CSS or XPath) as the second
      * parameter to only search within that element.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->see('Logout');                        // I can suppose user is logged in
      * $I->see('Sign Up', 'h1');                 // I can suppose it's a signup page
@@ -85,7 +85,7 @@ interface Web
      * Checks that the current page contains the given string in its
      * raw source code.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeInSource('<h1>Green eggs &amp; ham</h1>');
      * ```
@@ -131,7 +131,7 @@ interface Web
      *
      * Examples:
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->submitForm('#login', [
      *     'login' => 'davert',
@@ -168,7 +168,7 @@ interface Web
      *
      * You could write the following to submit it:
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->submitForm(
      *     '#userForm',
@@ -208,7 +208,7 @@ interface Web
      * This function works well when paired with `seeInFormFields()`
      * for quickly testing CRUD interfaces and form validation logic.
      *
-     * ``` php
+     * ```php
      * <?php
      * $form = [
      *      'field1' => 'value',
@@ -226,7 +226,7 @@ interface Web
      * you can use either the string value or boolean `true`/`false` which will
      * be replaced by the checkbox's value in the DOM.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->submitForm('#my-form', [
      *      'field1' => 'value',
@@ -288,7 +288,7 @@ interface Web
      *
      * Note that if the locator matches a button of type `submit`, the form will be submitted.
      *
-     * ``` php
+     * ```php
      * <?php
      * // simple link
      * $I->click('Logout');
@@ -311,7 +311,7 @@ interface Web
      * Checks that there's a link with the specified text.
      * Give a full URL as the second parameter to match links with that exact URL.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeLink('Logout'); // matches <a href="#">Logout</a>
      * $I->seeLink('Logout','/logout'); // matches <a href="/logout">Logout</a>
@@ -323,7 +323,7 @@ interface Web
      * Checks that the page doesn't contain a link with the given string.
      * If the second parameter is given, only links with a matching "href" attribute will be checked.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeLink('Logout'); // I suppose user is not logged in
      * $I->dontSeeLink('Checkout now', '/store/cart.php');
@@ -334,7 +334,7 @@ interface Web
     /**
      * Checks that current URI contains the given string.
      *
-     * ``` php
+     * ```php
      * <?php
      * // to match: /home/dashboard
      * $I->seeInCurrentUrl('home');
@@ -348,7 +348,7 @@ interface Web
      * Checks that the current URL is equal to the given string.
      * Unlike `seeInCurrentUrl`, this only matches the full URL.
      *
-     * ``` php
+     * ```php
      * <?php
      * // to match root url
      * $I->seeCurrentUrlEquals('/');
@@ -359,7 +359,7 @@ interface Web
     /**
      * Checks that the current URL matches the given regular expression.
      *
-     * ``` php
+     * ```php
      * <?php
      * // to match root url
      * $I->seeCurrentUrlMatches('~^/users/(\d+)~');
@@ -370,7 +370,7 @@ interface Web
     /**
      * Checks that the current URI doesn't contain the given string.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeInCurrentUrl('/users/');
      * ```
@@ -381,7 +381,7 @@ interface Web
      * Checks that the current URL doesn't equal the given string.
      * Unlike `dontSeeInCurrentUrl`, this only matches the full URL.
      *
-     * ``` php
+     * ```php
      * <?php
      * // current url is not root
      * $I->dontSeeCurrentUrlEquals('/');
@@ -392,7 +392,7 @@ interface Web
     /**
      * Checks that current url doesn't match the given regular expression.
      *
-     * ``` php
+     * ```php
      * <?php
      * // to match root url
      * $I->dontSeeCurrentUrlMatches('~^/users/(\d+)~');
@@ -404,7 +404,7 @@ interface Web
      * Executes the given regular expression against the current URI and returns the first capturing group.
      * If no parameters are provided, the full URI is returned.
      *
-     * ``` php
+     * ```php
      * <?php
      * $user_id = $I->grabFromCurrentUrl('~^/user/(\d+)/~');
      * $uri = $I->grabFromCurrentUrl();
@@ -415,7 +415,7 @@ interface Web
     /**
      * Checks that the specified checkbox is checked.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeCheckboxIsChecked('#agree'); // I suppose user agreed to terms
      * $I->seeCheckboxIsChecked('#signup_form input[type=checkbox]'); // I suppose user agreed to terms, If there is only one checkbox in form.
@@ -427,7 +427,7 @@ interface Web
     /**
      * Check that the specified checkbox is unchecked.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeCheckboxIsChecked('#agree'); // I suppose user didn't agree to terms
      * $I->seeCheckboxIsChecked('#signup_form input[type=checkbox]'); // I suppose user didn't check the first checkbox in form.
@@ -439,7 +439,7 @@ interface Web
      * Checks that the given input field or textarea *equals* (i.e. not just contains) the given value.
      * Fields are matched by label text, the "name" attribute, CSS, or XPath.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeInField('Body','Type your comment here');
      * $I->seeInField('form textarea[name=body]','Type your comment here');
@@ -457,7 +457,7 @@ interface Web
      * Checks that an input field or textarea doesn't contain the given value.
      * For fuzzy locators, the field is matched by label text, CSS and XPath.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeInField('Body','Type your comment here');
      * $I->dontSeeInField('form textarea[name=body]','Type your comment here');
@@ -474,7 +474,7 @@ interface Web
      * Checks if the array of form parameters (name => value) are set on the form matched with the
      * passed selector.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeInFormFields('form[name=myform]', [
      *      'input1' => 'value',
@@ -485,7 +485,7 @@ interface Web
      * For multi-select elements, or to check values of multiple elements with the same name, an
      * array may be passed:
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeInFormFields('.form-class', [
      *      'multiselect' => [
@@ -501,7 +501,7 @@ interface Web
      *
      * Additionally, checkbox values can be checked with a boolean.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeInFormFields('#form-id', [
      *      'checkbox1' => true,        // passes if checked
@@ -511,7 +511,7 @@ interface Web
      *
      * Pair this with submitForm for quick testing magic.
      *
-     * ``` php
+     * ```php
      * <?php
      * $form = [
      *      'field1' => 'value',
@@ -530,7 +530,7 @@ interface Web
      * Checks if the array of form parameters (name => value) are not set on the form matched with
      * the passed selector.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeInFormFields('form[name=myform]', [
      *      'input1' => 'non-existent value',
@@ -541,7 +541,7 @@ interface Web
      * To check that an element hasn't been assigned any one of many values, an array can be passed
      * as the value:
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeInFormFields('.form-class', [
      *      'fieldName' => [
@@ -553,7 +553,7 @@ interface Web
      *
      * Additionally, checkbox values can be checked with a boolean.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeInFormFields('#form-id', [
      *      'checkbox1' => true,        // fails if checked
@@ -566,7 +566,7 @@ interface Web
     /**
      * Selects an option in a select tag or in radio button group.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->selectOption('form select[name=account]', 'Premium');
      * $I->selectOption('form input[name=payment]', 'Monthly');
@@ -575,14 +575,14 @@ interface Web
      *
      * Provide an array for the second argument to select multiple options:
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->selectOption('Which OS do you use?', ['Windows', 'Linux']);
      * ```
      *
      * Or provide an associative array for the second argument to specifically define which selection method should be used:
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->selectOption('Which OS do you use?', ['text' => 'Windows']); // Only search by text 'Windows'
      * $I->selectOption('Which OS do you use?', ['value' => 'windows']); // Only search by value 'windows'
@@ -593,7 +593,7 @@ interface Web
     /**
      * Ticks a checkbox. For radio buttons, use the `selectOption` method instead.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->checkOption('#agree');
      * ```
@@ -603,7 +603,7 @@ interface Web
     /**
      * Unticks a checkbox.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->uncheckOption('#notify');
      * ```
@@ -613,7 +613,7 @@ interface Web
     /**
      * Fills a text field or textarea with the given string.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->fillField("//input[@type='text']", "Hello World!");
      * $I->fillField(['name' => 'email'], 'jon@example.com');
@@ -624,7 +624,7 @@ interface Web
     /**
      * Attaches a file relative to the Codeception `_data` directory to the given file upload field.
      *
-     * ``` php
+     * ```php
      * <?php
      * // file is stored in 'tests/_data/prices.xls'
      * $I->attachFile('input[@type="file"]', 'prices.xls');
@@ -637,7 +637,7 @@ interface Web
      * If a fuzzy locator is used, the element is found using CSS, XPath,
      * and by matching the full page source by regular expression.
      *
-     * ``` php
+     * ```php
      * <?php
      * $heading = $I->grabTextFrom('h1');
      * $heading = $I->grabTextFrom('descendant-or-self::h1');
@@ -650,7 +650,7 @@ interface Web
      * Finds the value for the given form field.
      * If a fuzzy locator is used, the field is found by field name, CSS, and XPath.
      *
-     * ``` php
+     * ```php
      * <?php
      * $name = $I->grabValueFrom('Name');
      * $name = $I->grabValueFrom('input[name=username]');
@@ -664,7 +664,7 @@ interface Web
      * Grabs the value of the given attribute value from the given element.
      * Fails if element is not found.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->grabAttributeFrom('#tooltip', 'title');
      * ```
@@ -699,7 +699,7 @@ interface Web
      * You can also specify expected attributes of this element.
      * Only works if `<html>` tag is present.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeElement('.error');
      * $I->seeElement('//form/input[1]');
@@ -716,7 +716,7 @@ interface Web
      * Checks that the given element is invisible or not present on the page.
      * You can also specify expected attributes of this element.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeElement('.error');
      * $I->dontSeeElement('//form/input[1]');
@@ -729,7 +729,7 @@ interface Web
     /**
      * Checks that there are a certain number of elements matched by the given locator on the page.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeNumberOfElements('tr', 10);
      * $I->seeNumberOfElements('tr', [0,10]); // between 0 and 10 elements
@@ -742,7 +742,7 @@ interface Web
     /**
      * Checks that the given option is selected.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeOptionIsSelected('#form input[name=payment]', 'Visa');
      * ```
@@ -754,7 +754,7 @@ interface Web
     /**
      * Checks that the given option is not selected.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->dontSeeOptionIsSelected('#form input[name=payment]', 'Visa');
      * ```
@@ -766,7 +766,7 @@ interface Web
     /**
      * Checks that the page title contains the given string.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeInTitle('Blog - Post #1');
      * ```
@@ -786,7 +786,7 @@ interface Web
      * Checks that a cookie with the given name is set.
      * You can set additional cookie params like `domain`, `path` as array passed in last argument.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->seeCookie('PHPSESSID');
      * ```
@@ -807,7 +807,7 @@ interface Web
      * Sets a cookie with the given name and value.
      * You can set additional cookie params like `domain`, `path`, `expires`, `secure` in array passed as last argument.
      *
-     * ``` php
+     * ```php
      * <?php
      * $I->setCookie('PHPSESSID', 'el4ukv0kqbvoirg7nkp4dncpk3');
      * ```


### PR DESCRIPTION
I guess these spaces are causing the blank line on top of each PHP code block - example: https://codeception.com/docs/modules/Symfony#amOnPage