### PR TITLE
Support PHPUnit 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.3]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "php": "^8.0",
         "ext-mbstring": "*",
         "guzzlehttp/psr7": "^2.0",
+        "phpunit/phpunit": "^9.5 | ^10.0 | ^11.0",
         "symfony/css-selector": ">=4.4.24 <8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5 | ^10.0",
         "php-webdriver/webdriver": "^1.12"
     },
     "conflict": {


### PR DESCRIPTION
I moved PHPUnit to `require` section because \Codeception\Constraint\Page and \Codeception\Exception\ElementNotFound extend classes provided by PHPUnit.