### PR TITLE
Declare nullable parameter types explicitly for PHP 8.4 compatibility

### DIFF
--- a/src/Lib/Interfaces/PageSourceSaver.php
+++ b/src/Lib/Interfaces/PageSourceSaver.php
@@ -27,5 +27,5 @@ interface PageSourceSaver
      * // saved to: tests/_output/debug/2017-05-26_14-24-11_4b3403665fea6.html
      * ```
      */
-    public function makeHtmlSnapshot(string $name = null): void;
+    public function makeHtmlSnapshot(?string $name = null): void;
 }

--- a/src/Lib/Interfaces/Web.php
+++ b/src/Lib/Interfaces/Web.php
@@ -275,7 +275,7 @@ interface Web
      * ]);
      * ```
      */
-    public function submitForm($selector, array $params, string $button = null): void;
+    public function submitForm($selector, array $params, ?string $button = null): void;
 
     /**
      * Perform a click on a link or a button, given by a locator.
@@ -317,7 +317,7 @@ interface Web
      * $I->seeLink('Logout','/logout'); // matches <a href="/logout">Logout</a>
      * ```
      */
-    public function seeLink(string $text, string $url = null): void;
+    public function seeLink(string $text, ?string $url = null): void;
 
     /**
      * Checks that the page doesn't contain a link with the given string.
@@ -410,7 +410,7 @@ interface Web
      * $uri = $I->grabFromCurrentUrl();
      * ```
      */
-    public function grabFromCurrentUrl(string $uri = null): mixed;
+    public function grabFromCurrentUrl(?string $uri = null): mixed;
 
     /**
      * Checks that the specified checkbox is checked.
@@ -692,7 +692,7 @@ interface Web
      *
      * @return string[]
      */
-    public function grabMultiple($cssOrXpath, string $attribute = null): array;
+    public function grabMultiple($cssOrXpath, ?string $attribute = null): array;
 
     /**
      * Checks that the given element exists on the page and is visible.


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types deprecates implicitly nullable parameter types in PHP 8.4