### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/psr7": "^2.0",
         "phpunit/phpunit": "^11.5 | ^12",
-        "symfony/css-selector": ">=4.4.24 <8.0"
+        "symfony/css-selector": ">=4.4.24 <9.0"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.12"


### PR DESCRIPTION
Symfony 8 is going to be released at the end of November.

According to https://github.com/symfony/symfony/blob/8.0/UPGRADE-8.0.md `symfony/css-selector` is not affected by any BC breaking changes.

I ran the test suite locally with `symfony/css-selector:8` and the tests were still green.

It would be great if we could get a new release after this PR was merged.